### PR TITLE
Improve tool card UX and add spawn tool rendering

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -33,6 +33,7 @@ pub struct AgentInfo {
     pub backend_kind: String,
     pub parent_agent_id: Option<u64>,
     pub name: String,
+    pub agent_type: Option<String>,
     pub status: AgentStatus,
     pub summary: String,
     pub created_at_ms: u64,
@@ -162,6 +163,7 @@ impl AgentRuntime {
             backend_kind,
             parent_agent_id,
             name,
+            agent_type: None,
             status: AgentStatus::Queued,
             summary: "Queued".to_string(),
             created_at_ms: now,
@@ -180,6 +182,12 @@ impl AgentRuntime {
             Some("Queued".to_string()),
         );
         info
+    }
+
+    pub fn update_agent_type(&mut self, agent_id: u64, agent_type: Option<String>) {
+        if let Some(info) = self.agents.get_mut(&agent_id) {
+            info.agent_type = agent_type;
+        }
     }
 
     pub fn mark_agent_running(&mut self, agent_id: u64, summary: Option<String>) -> bool {

--- a/src-tauri/src/claude.rs
+++ b/src-tauri/src/claude.rs
@@ -35,6 +35,7 @@ pub trait SubAgentEmitter: Send + Sync {
         tool_use_id: String,
         name: String,
         description: String,
+        agent_type: String,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = SubAgentHandle> + Send + '_>>;
 
     /// Called when a sub-agent completes (tool_result received for the spawn tool).
@@ -1363,7 +1364,7 @@ fn extract_spawn_description(input: Option<&Value>) -> String {
     String::new()
 }
 
-fn extract_spawn_info(block: &Value) -> Option<(String, String, String)> {
+fn extract_spawn_info(block: &Value) -> Option<(String, String, String, String)> {
     let name = block.get("name").and_then(Value::as_str)?;
     if !is_subagent_tool_name(name) {
         return None;
@@ -1371,12 +1372,27 @@ fn extract_spawn_info(block: &Value) -> Option<(String, String, String)> {
     let id = block.get("id").and_then(Value::as_str)?.to_string();
     let input = block.get("input");
     let description = extract_spawn_description(input);
-    let agent_name = input
+    let agent_type = input
         .and_then(|i| i.get("subagent_type").or(i.get("name")))
         .and_then(Value::as_str)
-        .unwrap_or(name)
+        .unwrap_or("")
         .to_string();
-    Some((id, agent_name, description))
+    // Prefer the short "description" field (3-5 word label) as the display name,
+    // falling back to subagent_type or the tool name.
+    let agent_name = input
+        .and_then(|i| i.get("description"))
+        .and_then(Value::as_str)
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            if !agent_type.is_empty() {
+                agent_type.clone()
+            } else {
+                name.to_string()
+            }
+        });
+    Some((id, agent_name, description, agent_type))
 }
 
 async fn read_claude_stdout(
@@ -1553,7 +1569,7 @@ fn track_pending_subagent_prompt_event(
             let Some(block) = event.get("content_block") else {
                 return;
             };
-            let Some((tool_use_id, _name, description)) = extract_spawn_info(block) else {
+            let Some((tool_use_id, _name, description, _agent_type)) = extract_spawn_info(block) else {
                 return;
             };
             pending_prompts.insert(
@@ -1628,17 +1644,17 @@ async fn detect_subagent_spawns(
         tracing::info!(
             "detect_subagent_spawns: found tool_use block: name={block_name} id={block_id}"
         );
-        if let Some((tool_use_id, name, description)) = extract_spawn_info(&block) {
+        if let Some((tool_use_id, name, description, agent_type)) = extract_spawn_info(&block) {
             if let Some(stream) = streams.get_mut(&tool_use_id) {
                 emit_subagent_task_prompt_if_needed(stream, &description);
                 continue; // Already registered
             }
             tracing::info!(
-                "detect_subagent_spawns: spawning sub-agent tool_use_id={tool_use_id} name={name}"
+                "detect_subagent_spawns: spawning sub-agent tool_use_id={tool_use_id} name={name} agent_type={agent_type}"
             );
             let has_explicit_task_prompt = !description.trim().is_empty();
             let handle = emitter
-                .on_subagent_spawned(tool_use_id.clone(), name, description)
+                .on_subagent_spawned(tool_use_id.clone(), name, description, agent_type)
                 .await;
             // Create a ClaudeInner that routes to the sub-agent's event channel
             let sa_inner = Arc::new(ClaudeInner {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,6 +102,7 @@ impl SubAgentEmitter for ClaudeSubAgentEmitter {
         tool_use_id: String,
         name: String,
         description: String,
+        agent_type: String,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = SubAgentHandle> + Send + '_>> {
         Box::pin(async move {
             let parent_agent_id = self.resolve_parent_agent_id().await;
@@ -123,13 +124,15 @@ impl SubAgentEmitter for ClaudeSubAgentEmitter {
                 } else {
                     name
                 };
-                let info = runtime.register_agent(
+                let mut info = runtime.register_agent(
                     conversation_id,
                     self.workspace_roots.clone(),
                     "claude".to_string(),
                     parent_agent_id,
                     display_name,
                 );
+                info.agent_type = if agent_type.is_empty() { None } else { Some(agent_type) };
+                runtime.update_agent_type(info.agent_id, info.agent_type.clone());
                 runtime.mark_agent_running(info.agent_id, Some("Running...".to_string()));
                 info
             };
@@ -154,6 +157,7 @@ impl SubAgentEmitter for ClaudeSubAgentEmitter {
                     "workspace_roots": self.workspace_roots,
                     "backend_kind": "claude",
                     "name": &agent_info.name,
+                    "agent_type": &agent_info.agent_type,
                     "parent_agent_id": parent_agent_id,
                 }
             });

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -6,6 +6,7 @@ export interface AgentInfo {
   agentId?: number;
   conversationId: number;
   name: string;
+  agentType?: string | null;
   summary: string;
   isTyping: boolean;
   hasError?: boolean;
@@ -218,6 +219,14 @@ export class AgentsPanel {
     const headerRight = document.createElement("div");
     headerRight.className = "agent-card-header-right";
 
+    if (agent.agentType) {
+      const typeBadge = document.createElement("span");
+      typeBadge.className = "agent-card-type-badge";
+      typeBadge.dataset.testid = "agent-card-type-badge";
+      typeBadge.textContent = agent.agentType;
+      headerRight.appendChild(typeBadge);
+    }
+
     if (childCount > 0) {
       const badge = document.createElement("span");
       badge.className = "agent-card-child-badge";
@@ -375,6 +384,7 @@ export class AgentsPanel {
       a.agentId === b.agentId &&
       a.conversationId === b.conversationId &&
       a.name === b.name &&
+      a.agentType === b.agentType &&
       a.summary === b.summary &&
       a.isTyping === b.isTyping &&
       a.hasError === b.hasError &&

--- a/src/app.ts
+++ b/src/app.ts
@@ -601,6 +601,7 @@ export class AppController {
       backend_kind: payload.data.backend_kind,
       parent_agent_id: payload.data.parent_agent_id,
       name: payload.data.name,
+      agent_type: payload.data.agent_type ?? null,
       status: "running",
       summary: "",
       created_at_ms: Date.now(),

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -25,6 +25,7 @@ export interface ConversationRegisteredData {
   workspace_roots: string[];
   backend_kind: string;
   name: string;
+  agent_type: string | null;
   parent_agent_id: number | null;
 }
 
@@ -50,6 +51,7 @@ export interface RuntimeAgent {
   backend_kind: string;
   parent_agent_id: number | null;
   name: string;
+  agent_type: string | null;
   status: RuntimeAgentStatus;
   summary: string;
   created_at_ms: number;

--- a/src/chat/tools.ts
+++ b/src/chat/tools.ts
@@ -1,6 +1,6 @@
 import { createTwoFilesPatch } from "diff";
 import type { ToolUseData } from "../core_types";
-import { escapeHtml } from "../renderer";
+import { escapeHtml, renderContent, wrapWithTruncation } from "../renderer";
 import type { ToolExecutionResult, ToolRequestType } from "../types";
 
 export type ToolOutputMode = "summary" | "compact" | "verbose";
@@ -8,7 +8,6 @@ export type ToolOutputMode = "summary" | "compact" | "verbose";
 export type DiffDisplayMode = ToolOutputMode;
 const TOOL_OUTPUT_MODE_KEY = "tyde-tool-output-mode";
 const LEGACY_DIFF_MODE_KEY = "tyde-diff-display-mode";
-const DEFAULT_MAX_DIFF_LINES = 20;
 const COMPACT_MAX_READ_FILES = 8;
 const COMPACT_MAX_SEARCH_TYPES = 12;
 
@@ -189,10 +188,9 @@ export function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
-export function createPreBlock(text: string, fullHeight = false): HTMLElement {
+export function createPreBlock(text: string): HTMLElement {
   const pre = document.createElement("pre");
   pre.className = "tool-result-pre";
-  if (fullHeight) pre.classList.add("tool-result-pre-full");
   pre.textContent = text;
   return pre;
 }
@@ -204,8 +202,12 @@ export function buildCommandOutputBlock(
 ): HTMLElement {
   const wrapper = document.createElement("div");
   wrapper.className = `tool-result-output ${className}`;
-  if (fullHeight) wrapper.classList.add("tool-result-output-full");
-  wrapper.appendChild(createPreBlock(output, fullHeight));
+  if (fullHeight) {
+    wrapper.appendChild(createPreBlock(output));
+  } else {
+    const pre = createPreBlock(output);
+    wrapper.innerHTML = wrapWithTruncation(pre.outerHTML, output.length, 0);
+  }
   return wrapper;
 }
 
@@ -230,7 +232,7 @@ function renderInlineDiff(
   before: string,
   after: string,
   filePath: string,
-  maxLines: number | null,
+  truncate: boolean,
 ): HTMLElement {
   const patch = createTwoFilesPatch(filePath, filePath, before, after, "", "", {
     context: 2,
@@ -246,10 +248,6 @@ function renderInlineDiff(
   }
 
   const diffLines = lines.slice(startIdx);
-  const totalLines = diffLines.length;
-  const displayLines =
-    maxLines !== null ? diffLines.slice(0, maxLines) : diffLines;
-  const truncated = maxLines !== null && totalLines > maxLines;
 
   const container = document.createElement("div");
   container.className = "inline-diff-preview";
@@ -257,7 +255,7 @@ function renderInlineDiff(
   const pre = document.createElement("pre");
   pre.className = "inline-diff-code";
 
-  for (const line of displayLines) {
+  for (const line of diffLines) {
     const lineEl = document.createElement("div");
     lineEl.className = "inline-diff-line";
 
@@ -277,11 +275,14 @@ function renderInlineDiff(
 
   container.appendChild(pre);
 
-  if (truncated) {
-    const indicator = document.createElement("div");
-    indicator.className = "inline-diff-truncated";
-    indicator.textContent = `[${totalLines - maxLines!} more lines...]`;
-    container.appendChild(indicator);
+  if (truncate) {
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = wrapWithTruncation(
+      container.outerHTML,
+      diffLines.length,
+      0,
+    );
+    return wrapper;
   }
 
   return container;
@@ -466,6 +467,9 @@ function toolRequestHeaderDetail(toolType: ToolRequestType): string {
     case "RunCommand":
       return formatHeaderDetail(toolType.command, 96);
     case "ReadFiles":
+      if (toolType.file_paths.length === 1) {
+        return formatHeaderDetail(toolType.file_paths[0], 72);
+      }
       return `${toolType.file_paths.length} ${suffixForCount(toolType.file_paths.length, "file", "files")}`;
     case "SearchTypes":
       return `search ${toolType.type_name}`;
@@ -479,6 +483,7 @@ function toolRequestHeaderDetail(toolType: ToolRequestType): string {
 function completionHeaderDetail(
   card: HTMLElement,
   result: ToolExecutionResult,
+  toolName: string,
 ): string {
   const base = cardHeaderBaseDetail(card);
   switch (result.kind) {
@@ -498,6 +503,9 @@ function completionHeaderDetail(
         0,
       );
       const fileCount = result.files.length;
+      if (fileCount === 1) {
+        return `${formatHeaderDetail(result.files[0].path, 72)} · ${formatBytes(totalBytes)}`;
+      }
       return `read ${fileCount} ${suffixForCount(fileCount, "file", "files")} · ${formatBytes(totalBytes)}`;
     }
     case "SearchTypes":
@@ -511,6 +519,9 @@ function completionHeaderDetail(
     case "Error":
       return `error · ${summarizeSingleLine(result.short_message, 90)}`;
     case "Other": {
+      if (isSpawnTool(toolName) && typeof result.result === "string") {
+        return `response · ${formatBytes(result.result.length)}`;
+      }
       const serialized = safeJsonStringify(result.result, false);
       return `result json · ${formatBytes(serialized.length)}`;
     }
@@ -534,14 +545,10 @@ export function toolRequestSummary(
       });
       return null;
     }
-    case "RunCommand": {
-      const wrap = document.createElement("div");
-      wrap.className = "tool-request-summary";
-      wrap.innerHTML = `<div class="tool-request-row"><code class="inline-code">${escapeHtml(toolType.command)}</code></div>
-          <div class="tool-request-meta">${escapeHtml(toolType.working_directory)}</div>`;
-      return wrap;
-    }
+    case "RunCommand":
+      return null;
     case "ReadFiles": {
+      if (toolType.file_paths.length === 1) return null;
       const wrap = document.createElement("div");
       wrap.className = "tool-request-summary";
       const preview = toolType.file_paths
@@ -588,6 +595,7 @@ export function toolResultElement(
   state: ToolState,
   toolCallId: string,
   result: ToolExecutionResult,
+  toolName: string,
 ): HTMLElement | null {
   switch (result.kind) {
     case "ModifyFile": {
@@ -600,13 +608,12 @@ export function toolResultElement(
         if (mode === "summary" || !diffEntry) return;
         const diffContainer = document.createElement("div");
         diffContainer.className = "inline-diff-container";
-        const maxLines = mode === "compact" ? DEFAULT_MAX_DIFF_LINES : null;
         diffContainer.appendChild(
           renderInlineDiff(
             diffEntry.before,
             diffEntry.after,
             diffEntry.filePath,
-            maxLines,
+            mode === "compact",
           ),
         );
         root.appendChild(diffContainer);
@@ -625,60 +632,31 @@ export function toolResultElement(
         const hasStderr = stderrLines > 0;
 
         if (mode === "summary") {
-          const parts = [`exit ${result.exit_code}`];
-          if (hasStdout) parts.push(`stdout ${stdoutLines}L`);
-          if (hasStderr) parts.push(`stderr ${stderrLines}L`);
-          if (!hasStdout && !hasStderr) parts.push("no output");
-          root.appendChild(createMetaLine(parts.join(" · ")));
           return;
         }
 
         const fullHeight = mode === "verbose";
-        const header = document.createElement("div");
-        header.className = "tool-result-command-header";
-
-        const icon = document.createElement("span");
-        icon.className = "tool-result-icon";
-        icon.textContent = "▶";
-
-        const exit = document.createElement("span");
-        exit.className =
-          result.exit_code === 0
-            ? "tool-result-exit-success"
-            : "tool-result-exit-failure";
-        exit.textContent = `exit ${result.exit_code}`;
-        header.append(icon, exit);
-        root.appendChild(header);
 
         if (!hasStdout && !hasStderr) {
-          root.appendChild(createMetaLine("No command output"));
           return;
         }
 
         if (hasStdout) {
           root.appendChild(
-            createToolResultSection(
-              `stdout (${stdoutLines} lines)`,
-              buildCommandOutputBlock(
-                result.stdout,
-                "tool-result-stdout",
-                fullHeight,
-              ),
-              fullHeight || (result.exit_code === 0 && !hasStderr),
+            buildCommandOutputBlock(
+              result.stdout,
+              "tool-result-stdout",
+              fullHeight,
             ),
           );
         }
 
         if (hasStderr) {
           root.appendChild(
-            createToolResultSection(
-              `stderr (${stderrLines} lines)`,
-              buildCommandOutputBlock(
-                result.stderr,
-                "tool-result-stderr",
-                fullHeight,
-              ),
-              fullHeight || result.exit_code !== 0,
+            buildCommandOutputBlock(
+              result.stderr,
+              "tool-result-stderr",
+              fullHeight,
             ),
           );
         }
@@ -689,19 +667,12 @@ export function toolResultElement(
     case "ReadFiles": {
       const root = document.createElement("div");
       root.className = "tool-result tool-result-read";
-      const totalBytes = result.files.reduce(
-        (sum, file) => sum + file.bytes,
-        0,
-      );
       const updateResult = (mode: ToolOutputMode) => {
         root.replaceChildren();
-        if (mode === "summary") {
-          const suffix = result.files.length === 1 ? "" : "s";
-          root.appendChild(
-            createMetaLine(
-              `Read ${result.files.length} file${suffix} · ${formatBytes(totalBytes)}`,
-            ),
-          );
+        if (
+          mode === "summary" ||
+          (mode === "compact" && result.files.length === 1)
+        ) {
           return;
         }
 
@@ -787,10 +758,7 @@ export function toolResultElement(
         root.appendChild(
           createToolResultSection(
             "Documentation",
-            createPreBlock(
-              documentation || "No documentation returned",
-              fullHeight,
-            ),
+            createPreBlock(documentation || "No documentation returned"),
             fullHeight,
           ),
         );
@@ -832,7 +800,7 @@ export function toolResultElement(
           root.appendChild(
             createToolResultSection(
               "Details",
-              createPreBlock(result.detailed_message, fullHeight),
+              createPreBlock(result.detailed_message),
               true,
             ),
           );
@@ -842,6 +810,9 @@ export function toolResultElement(
       return root;
     }
     case "Other": {
+      if (isSpawnTool(toolName) && typeof result.result === "string") {
+        return renderSpawnToolResult(result.result);
+      }
       const root = document.createElement("div");
       root.className = "tool-result tool-result-docs";
       const jsonCompact = safeJsonStringify(result.result, false);
@@ -857,7 +828,7 @@ export function toolResultElement(
         root.appendChild(
           createToolResultSection(
             "Result JSON",
-            createPreBlock(jsonPretty, mode === "verbose"),
+            createPreBlock(jsonPretty),
             mode === "verbose",
           ),
         );
@@ -866,6 +837,25 @@ export function toolResultElement(
       return root;
     }
   }
+}
+
+function renderSpawnToolResult(text: string): HTMLElement {
+  const root = document.createElement("div");
+  root.className = "tool-result tool-result-spawn";
+  const rendered = renderContent(text);
+  const updateResult = (mode: ToolOutputMode) => {
+    root.replaceChildren();
+    if (mode === "summary") return;
+    const content = document.createElement("div");
+    content.className = "message-content spawn-result-content";
+    content.innerHTML =
+      mode === "verbose"
+        ? rendered
+        : wrapWithTruncation(rendered, text.length, 0);
+    root.appendChild(content);
+  };
+  bindToolOutputRenderer(root, updateResult);
+  return root;
 }
 
 function createToggleHandler(
@@ -1091,7 +1081,7 @@ export function handleToolRequest(
 export function handleToolCompleted(
   state: ToolState,
   toolCallId: string,
-  _toolName: string,
+  toolName: string,
   toolResult: ToolExecutionResult,
   success: boolean,
   scrollToBottom: () => void,
@@ -1102,7 +1092,7 @@ export function handleToolCompleted(
   const header = card.querySelector(".tool-card-header") as HTMLElement | null;
   const statusEl = card.querySelector(".tool-status-text");
 
-  setCardHeaderDetail(card, completionHeaderDetail(card, toolResult));
+  setCardHeaderDetail(card, completionHeaderDetail(card, toolResult, toolName));
 
   if (toolResult.kind === "ModifyFile" && header && statusEl) {
     const diffId = state.toolDiffByCall.get(toolCallId);
@@ -1127,7 +1117,7 @@ export function handleToolCompleted(
   }
 
   const details = card.querySelector(".tool-details") as HTMLElement | null;
-  const resultEl = toolResultElement(state, toolCallId, toolResult);
+  const resultEl = toolResultElement(state, toolCallId, toolResult, toolName);
   if (details && resultEl) {
     details.appendChild(resultEl);
   }

--- a/src/home_view.ts
+++ b/src/home_view.ts
@@ -225,6 +225,14 @@ export class HomeView {
     const headerRight = document.createElement("div");
     headerRight.className = "agent-card-header-right";
 
+    if (agent.agent_type) {
+      const typeBadge = document.createElement("span");
+      typeBadge.className = "agent-card-type-badge";
+      typeBadge.dataset.testid = "agent-card-type-badge";
+      typeBadge.textContent = agent.agent_type;
+      headerRight.appendChild(typeBadge);
+    }
+
     if (childCount > 0) {
       const badge = document.createElement("span");
       badge.className = "agent-card-child-badge";
@@ -408,6 +416,8 @@ export class HomeView {
       const candidate = next[index];
       return (
         agent.agent_id === candidate.agent_id &&
+        agent.name === candidate.name &&
+        agent.agent_type === candidate.agent_type &&
         agent.status === candidate.status &&
         agent.summary === candidate.summary &&
         agent.updated_at_ms === candidate.updated_at_ms &&

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -385,20 +385,7 @@ export function wrapWithTruncation(
 ): string {
   if (rawLength <= threshold) return html;
 
-  return `<div class="truncatable collapsed">
-    <div class="truncatable-content">${html}</div>
-    <div class="truncatable-fade"></div>
-    <button class="truncatable-toggle" onclick="
-      const container = this.closest('.truncatable');
-      if (container.classList.contains('collapsed')) {
-        container.classList.remove('collapsed');
-        this.textContent = 'Show less';
-      } else {
-        container.classList.add('collapsed');
-        this.textContent = 'Show more';
-      }
-    ">Show more</button>
-  </div>`;
+  return `<div class="truncatable collapsed"><div class="truncatable-content">${html}</div><div class="truncatable-fade"></div><button class="truncatable-toggle" onclick="const container = this.closest('.truncatable'); if (container.classList.contains('collapsed')) { container.classList.remove('collapsed'); this.textContent = 'Show less'; } else { container.classList.add('collapsed'); this.textContent = 'Show more'; }">Show more</button></div>`;
 }
 
 export function renderCommandOutput(

--- a/src/styles.css
+++ b/src/styles.css
@@ -523,8 +523,8 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  margin-top: 8px;
-  padding-top: 6px;
+  margin-top: 4px;
+  padding-top: 3px;
   border-top: 1px solid var(--border-primary);
   font-size: calc(var(--base-font-size) * 0.8571);
   color: var(--text-tertiary);
@@ -1079,7 +1079,7 @@ body {
   border: none;
   border-left: none;
   border-radius: 4px;
-  padding: 4px 6px;
+  padding: 2px 6px;
   margin: 0;
   font-size: 0.9em;
   width: 100%;
@@ -1158,9 +1158,19 @@ body {
 }
 
 .tool-details.expanded {
-  max-height: 1200px;
-  margin-top: 8px;
-  overflow-x: auto;
+  max-height: none;
+  margin-top: 2px;
+}
+
+.tool-card-spawn .tool-details.expanded {
+  margin-top: 2px;
+}
+
+.spawn-result-content {
+  font-family: var(--font-sans);
+  font-size: calc(var(--base-font-size) * 0.93);
+  line-height: 1.5;
+  padding: 2px 4px;
 }
 
 .tool-request-summary {
@@ -3710,10 +3720,15 @@ body {
 
 /* === Tool Result Types === */
 .tool-result {
-  margin-top: 6px;
-  padding: 6px 8px;
+  margin-top: 0;
+  padding: 0;
   border-radius: 4px;
   font-size: 0.85em;
+}
+
+.tool-result-spawn {
+  margin-top: 2px;
+  padding: 0;
 }
 
 .tool-result-modify {
@@ -3789,8 +3804,6 @@ body {
 }
 
 .tool-result-output {
-  max-height: 200px;
-  overflow-y: auto;
   font-family: var(--font-mono);
   font-size: 0.9em;
   white-space: pre-wrap;
@@ -3798,7 +3811,6 @@ body {
 }
 
 .tool-result-output-full {
-  max-height: none;
   overflow: visible;
 }
 
@@ -3843,14 +3855,7 @@ body {
   font-family: var(--font-mono);
   font-size: 0.9em;
   white-space: pre-wrap;
-  max-height: 300px;
-  overflow-y: auto;
   color: var(--text-primary);
-}
-
-.tool-result-pre-full {
-  max-height: none;
-  overflow: visible;
 }
 
 .tool-result-error {
@@ -3953,8 +3958,9 @@ body {
 }
 
 .truncatable.collapsed .truncatable-content {
-  max-height: 400px;
+  max-height: 200px;
   overflow: hidden;
+  padding-bottom: 20px;
 }
 
 .truncatable-fade {
@@ -3964,30 +3970,39 @@ body {
 .truncatable.collapsed .truncatable-fade {
   display: block;
   position: absolute;
-  bottom: 28px;
+  bottom: 0;
   left: 0;
   right: 0;
-  height: 60px;
+  height: 28px;
   background: linear-gradient(transparent, var(--assistant-msg-bg));
   pointer-events: none;
+}
+
+.tool-result-section .truncatable.collapsed .truncatable-fade {
+  background: linear-gradient(transparent, var(--bg-secondary));
 }
 
 .truncatable-toggle {
   display: block;
   background: transparent;
-  border: 1px solid var(--border-secondary);
+  border: none;
   color: var(--accent-link);
   cursor: pointer;
-  font-size: 0.85em;
+  font-size: calc(var(--base-font-size) * 0.85);
   padding: 4px 12px;
-  border-radius: 3px;
-  margin-top: 8px;
   width: 100%;
   text-align: center;
 }
 
+.truncatable.collapsed .truncatable-toggle {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 .truncatable-toggle:hover {
-  background: var(--bg-tertiary);
+  text-decoration: underline;
 }
 
 /* === Stream Error Banner === */
@@ -8240,7 +8255,6 @@ body {
 .inline-diff-preview {
   border: 1px solid var(--border-primary);
   border-radius: 4px;
-  overflow: hidden;
   font-size: 12px;
 }
 
@@ -8821,6 +8835,16 @@ body {
 .agent-card-collapse-toggle:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
+}
+
+.agent-card-type-badge {
+  font-size: calc(var(--base-font-size) * 0.7143);
+  color: var(--accent-link);
+  background: color-mix(in srgb, var(--accent-link) 15%, transparent);
+  padding: 1px 6px;
+  border-radius: 8px;
+  white-space: nowrap;
+  text-transform: capitalize;
 }
 
 .agent-card-child-badge {

--- a/src/workspace_view.ts
+++ b/src/workspace_view.ts
@@ -2183,6 +2183,7 @@ export class WorkspaceView {
       agentId: agent.agent_id,
       conversationId: agent.conversation_id,
       name,
+      agentType: agent.agent_type,
       summary:
         agent.summary.trim() || this.runtimeAgentSummaryFallback(agent.status),
       isTyping,


### PR DESCRIPTION
Cleaned up tool card presentation by removing verbose section headers, redundant meta-lines, and unnecessary output wrappers so results are more scannable. Single-file reads now show the file path directly in the card header instead of a generic count. Diffs use content-aware truncation instead of a fixed line limit. Spawn tool results render as markdown with truncation support, and command output uses the same truncation system as the rest of the UI.