### PR TITLE
Reorder sidebar tabs and add agents toolbar

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -21,6 +21,9 @@ export class AgentsPanel {
   private agents: AgentInfo[] = [];
   private projectFilter: string | null = null;
   private collapsedParents: Set<number> = new Set();
+  private hideInactive = false;
+  private hideSubAgents = false;
+  private searchQuery = "";
   public onAgentClick: ((agent: AgentInfo) => void) | null = null;
   public onAgentAction:
     | ((agent: AgentInfo, action: AgentCardAction) => void)
@@ -92,10 +95,7 @@ export class AgentsPanel {
   render(): void {
     this.container.innerHTML = "";
 
-    const header = document.createElement("div");
-    header.className = "agents-panel-header";
-    header.innerHTML = '<span class="agents-panel-title">Agents</span>';
-    this.container.appendChild(header);
+    this.container.appendChild(this.buildToolbar());
 
     const filtered = this.filteredAgents();
     if (filtered.length === 0) {
@@ -152,8 +152,86 @@ export class AgentsPanel {
   }
 
   private filteredAgents(): AgentInfo[] {
-    if (this.projectFilter === null) return [...this.agents];
-    return this.agents.filter((a) => a.projectId === this.projectFilter);
+    let result = [...this.agents];
+    if (this.projectFilter !== null) {
+      result = result.filter((a) => a.projectId === this.projectFilter);
+    }
+    if (this.hideInactive) {
+      result = result.filter((a) => this.isActive(a));
+    }
+    if (this.hideSubAgents) {
+      result = result.filter((a) => a.parentAgentId == null);
+    }
+    if (this.searchQuery) {
+      const q = this.searchQuery.toLowerCase();
+      result = result.filter(
+        (a) =>
+          a.name.toLowerCase().includes(q) ||
+          a.summary.toLowerCase().includes(q),
+      );
+    }
+    return result;
+  }
+
+  private isActive(agent: AgentInfo): boolean {
+    if (agent.runtimeStatus != null) {
+      return (
+        agent.runtimeStatus === "queued" ||
+        agent.runtimeStatus === "running" ||
+        agent.runtimeStatus === "waiting_input"
+      );
+    }
+    return agent.isTyping;
+  }
+
+  private buildToolbar(): HTMLElement {
+    const toolbar = document.createElement("div");
+    toolbar.className = "agents-toolbar";
+    toolbar.dataset.testid = "agents-toolbar";
+
+    const searchInput = document.createElement("input");
+    searchInput.type = "text";
+    searchInput.className = "agents-search";
+    searchInput.placeholder = "Search agents\u2026";
+    searchInput.setAttribute("aria-label", "Search agents");
+    searchInput.value = this.searchQuery;
+    searchInput.addEventListener("input", () => {
+      this.searchQuery = searchInput.value;
+      this.render();
+    });
+
+    const hideInactiveBtn = document.createElement("button");
+    hideInactiveBtn.type = "button";
+    hideInactiveBtn.className = "agents-toolbar-btn";
+    if (this.hideInactive)
+      hideInactiveBtn.classList.add("agents-toolbar-btn-active");
+    hideInactiveBtn.dataset.testid = "agents-hide-inactive";
+    hideInactiveBtn.textContent = "◑";
+    hideInactiveBtn.title = "Hide inactive agents";
+    hideInactiveBtn.setAttribute("aria-label", "Hide inactive agents");
+    hideInactiveBtn.addEventListener("click", () => {
+      this.hideInactive = !this.hideInactive;
+      this.render();
+    });
+
+    const hideSubBtn = document.createElement("button");
+    hideSubBtn.type = "button";
+    hideSubBtn.className = "agents-toolbar-btn";
+    if (this.hideSubAgents)
+      hideSubBtn.classList.add("agents-toolbar-btn-active");
+    hideSubBtn.dataset.testid = "agents-hide-subagents";
+    hideSubBtn.textContent = "⊟";
+    hideSubBtn.title = "Hide sub-agents";
+    hideSubBtn.setAttribute("aria-label", "Hide sub-agents");
+    hideSubBtn.addEventListener("click", () => {
+      this.hideSubAgents = !this.hideSubAgents;
+      this.render();
+    });
+
+    toolbar.appendChild(searchInput);
+    toolbar.appendChild(hideInactiveBtn);
+    toolbar.appendChild(hideSubBtn);
+    return toolbar;
   }
 
   private buildEmptyState(): HTMLElement {

--- a/src/home_view.ts
+++ b/src/home_view.ts
@@ -22,6 +22,10 @@ export class HomeView {
   private agentsLoading = false;
   private actionListenerController: AbortController | null = null;
   private collapsedParents: Set<number> = new Set();
+  private homeHideInactive = false;
+  private homeHideSubAgents = false;
+  private homeHideOtherWorkspaces = false;
+  private homeSearchQuery = "";
   onOpenWorkspace: (() => void) | null = null;
   onOpenRemoteWorkspace: (() => void) | null = null;
   onNewBridgeChat: ((backendOverride?: BackendKind) => void) | null = null;
@@ -123,16 +127,19 @@ export class HomeView {
     section.className = "home-agents-section";
     section.dataset.testid = "home-agents-section";
 
+    section.appendChild(this.buildAgentsToolbar());
+
     if (this.agentsLoading && !this.cachedAgents) {
       const loading = document.createElement("div");
       loading.className = "panel-loading";
-      loading.innerHTML = '<div class="loading-spinner"></div> Loading agents…';
+      loading.innerHTML =
+        '<div class="loading-spinner"></div> Loading agents\u2026';
       section.appendChild(loading);
       return section;
     }
 
-    const agents = this.cachedAgents ?? [];
-    if (agents.length === 0) {
+    const filtered = this.filteredHomeAgents();
+    if (filtered.length === 0) {
       const empty = document.createElement("div");
       empty.className = "agents-empty-state";
       empty.innerHTML =
@@ -146,10 +153,10 @@ export class HomeView {
     // Build parent→children map for hierarchy display
     const childrenByParent = new Map<number, RuntimeAgent[]>();
     const roots: RuntimeAgent[] = [];
-    for (const agent of agents) {
+    for (const agent of filtered) {
       if (
         agent.parent_agent_id != null &&
-        agents.some((a) => a.agent_id === agent.parent_agent_id)
+        filtered.some((a) => a.agent_id === agent.parent_agent_id)
       ) {
         const siblings = childrenByParent.get(agent.parent_agent_id) ?? [];
         siblings.push(agent);
@@ -177,6 +184,104 @@ export class HomeView {
 
     section.appendChild(list);
     return section;
+  }
+
+  private buildAgentsToolbar(): HTMLElement {
+    const toolbar = document.createElement("div");
+    toolbar.className = "agents-toolbar";
+    toolbar.dataset.testid = "home-agents-toolbar";
+
+    const searchInput = document.createElement("input");
+    searchInput.type = "text";
+    searchInput.className = "agents-search";
+    searchInput.placeholder = "Search agents\u2026";
+    searchInput.setAttribute("aria-label", "Search agents");
+    searchInput.value = this.homeSearchQuery;
+    searchInput.addEventListener("input", () => {
+      this.homeSearchQuery = searchInput.value;
+      this.render();
+    });
+
+    const hideInactiveBtn = document.createElement("button");
+    hideInactiveBtn.type = "button";
+    hideInactiveBtn.className = "agents-toolbar-btn";
+    if (this.homeHideInactive)
+      hideInactiveBtn.classList.add("agents-toolbar-btn-active");
+    hideInactiveBtn.dataset.testid = "home-agents-hide-inactive";
+    hideInactiveBtn.textContent = "◑";
+    hideInactiveBtn.title = "Hide inactive agents";
+    hideInactiveBtn.setAttribute("aria-label", "Hide inactive agents");
+    hideInactiveBtn.addEventListener("click", () => {
+      this.homeHideInactive = !this.homeHideInactive;
+      this.render();
+    });
+
+    const hideSubBtn = document.createElement("button");
+    hideSubBtn.type = "button";
+    hideSubBtn.className = "agents-toolbar-btn";
+    if (this.homeHideSubAgents)
+      hideSubBtn.classList.add("agents-toolbar-btn-active");
+    hideSubBtn.dataset.testid = "home-agents-hide-subagents";
+    hideSubBtn.textContent = "⊟";
+    hideSubBtn.title = "Hide sub-agents";
+    hideSubBtn.setAttribute("aria-label", "Hide sub-agents");
+    hideSubBtn.addEventListener("click", () => {
+      this.homeHideSubAgents = !this.homeHideSubAgents;
+      this.render();
+    });
+
+    const hideOtherBtn = document.createElement("button");
+    hideOtherBtn.type = "button";
+    hideOtherBtn.className = "agents-toolbar-btn";
+    if (this.homeHideOtherWorkspaces)
+      hideOtherBtn.classList.add("agents-toolbar-btn-active");
+    hideOtherBtn.dataset.testid = "home-agents-hide-other-workspaces";
+    hideOtherBtn.textContent = "⌂";
+    hideOtherBtn.title = "Hide agents from other workspaces";
+    hideOtherBtn.setAttribute(
+      "aria-label",
+      "Hide agents from other workspaces",
+    );
+    hideOtherBtn.addEventListener("click", () => {
+      this.homeHideOtherWorkspaces = !this.homeHideOtherWorkspaces;
+      this.render();
+    });
+
+    toolbar.appendChild(searchInput);
+    toolbar.appendChild(hideInactiveBtn);
+    toolbar.appendChild(hideSubBtn);
+    toolbar.appendChild(hideOtherBtn);
+    return toolbar;
+  }
+
+  private filteredHomeAgents(): RuntimeAgent[] {
+    const agents = this.cachedAgents ?? [];
+    let result = [...agents];
+    if (this.homeHideInactive) {
+      result = result.filter(
+        (a) =>
+          a.status === "queued" ||
+          a.status === "running" ||
+          a.status === "waiting_input",
+      );
+    }
+    if (this.homeHideSubAgents) {
+      result = result.filter((a) => a.parent_agent_id == null);
+    }
+    if (this.homeHideOtherWorkspaces) {
+      result = result.filter(
+        (a) => a.parent_agent_id != null || a.workspace_roots.length === 0,
+      );
+    }
+    if (this.homeSearchQuery) {
+      const q = this.homeSearchQuery.toLowerCase();
+      result = result.filter(
+        (a) =>
+          a.name.toLowerCase().includes(q) ||
+          a.summary.toLowerCase().includes(q),
+      );
+    }
+    return result;
   }
 
   private buildAgentCard(

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -37,7 +37,7 @@ const STATE_MARKER = "__WORKBENCH_LAYOUT_V1__";
 const WIDGET_TITLES: Record<WidgetId, string> = {
   git: "Git",
   files: "Files",
-  sessions: "Sessions",
+  sessions: "History",
   agents: "Agents",
   terminal: "Terminal",
 };
@@ -69,12 +69,12 @@ function defaultState(): WorkbenchState {
     },
     widgetOrder: {
       left: ["files", "git"],
-      right: ["sessions", "agents"],
+      right: ["agents", "sessions"],
       bottom: ["terminal"],
     },
     activeWidget: {
       left: "files",
-      right: "sessions",
+      right: "agents",
       bottom: "terminal",
     },
     centerView: "chat",
@@ -258,7 +258,7 @@ function migrateLegacyDefaultDocking(state: WorkbenchState): WorkbenchState {
     },
     activeWidget: {
       left: state.activeWidget.left ?? "files",
-      right: "sessions",
+      right: "agents",
       bottom: "terminal",
     },
     rightVisible: true,

--- a/src/styles.css
+++ b/src/styles.css
@@ -8642,18 +8642,69 @@ body {
   background: var(--bg-secondary);
 }
 
-.agents-panel-header {
+.agents-toolbar {
   display: flex;
   align-items: center;
-  padding: 8px 12px;
+  gap: 4px;
+  padding: 6px 8px;
   border-bottom: 1px solid var(--border-primary);
   flex-shrink: 0;
 }
 
-.agents-panel-title {
-  font-weight: 600;
-  font-size: calc(var(--base-font-size) * 0.9286);
-  color: var(--text-bright);
+.agents-search {
+  flex: 1;
+  min-width: 60px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-input);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: calc(var(--base-font-size) * 0.8571);
+  font-family: var(--font-sans);
+}
+
+.agents-search:focus {
+  outline: none;
+  border-color: var(--border-focus);
+}
+
+.agents-search::placeholder {
+  color: var(--text-tertiary);
+}
+
+.agents-toolbar-btn {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  color: var(--text-secondary);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: calc(var(--base-font-size) * 0.8571);
+  line-height: 1;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
+}
+
+.agents-toolbar-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.agents-toolbar-btn-active {
+  background: color-mix(in srgb, var(--accent-primary) 18%, var(--bg-primary));
+  border-color: color-mix(
+    in srgb,
+    var(--accent-primary) 55%,
+    var(--border-primary)
+  );
+  color: var(--text-primary);
 }
 
 .agents-empty-state {

--- a/tests/e2e/chat.test.ts
+++ b/tests/e2e/chat.test.ts
@@ -73,6 +73,19 @@ async function openAgentsWidget(): Promise<void> {
   }, sel.dockWidgetTab);
 }
 
+async function openSessionsWidget(): Promise<void> {
+  await browser.waitUntil(
+    async () => (await (await $$(sel.dockWidgetTab)).length) > 0,
+    { timeout: 5000, timeoutMsg: 'Expected dock widget tabs to be available' },
+  );
+
+  await browser.execute((tabSel: string) => {
+    const tabs = Array.from(document.querySelectorAll(tabSel)) as HTMLElement[];
+    const tab = tabs.find((el) => el.offsetParent !== null && (el.textContent ?? '').trim() === 'History');
+    tab?.click();
+  }, sel.dockWidgetTab);
+}
+
 async function clickVisibleSessionsRefresh(timeoutMsg: string): Promise<void> {
   await browser.waitUntil(
     async () => browser.execute((buttonSel: string) => {
@@ -991,6 +1004,7 @@ describe('Chat tab lifecycle', () => {
     });
 
     // --- Sessions panel loads data ---
+    await openSessionsWidget();
     await browser.waitUntil(
       async () => (await getVisibleSessionsPanelText()).length > 0,
       { timeout: 5000, timeoutMsg: 'Expected visible sessions panel in workspace view' },
@@ -1086,6 +1100,7 @@ describe('Sessions backend behavior', () => {
     const input = await $(sel.messageInput);
     await input.waitForDisplayed({ timeout: 5000 });
 
+    await openSessionsWidget();
     await browser.waitUntil(
       async () => (await getVisibleSessionsPanelText()).length > 0,
       { timeout: 5000, timeoutMsg: 'Expected visible sessions panel in workspace view' },
@@ -1553,7 +1568,7 @@ describe('Agents panel parity', () => {
   it('shows runtime agents in both the project and home agents views and supports interrupt/remove controls', async () => {
     await openWorkspace();
 
-    await spawnRuntimeAgent('Bridge Worker', { completionDelayMs: 5000 });
+    await spawnRuntimeAgent('Bridge Worker', { completionDelayMs: 15000 });
     await openAgentsWidget();
 
     await browser.waitUntil(
@@ -1568,11 +1583,19 @@ describe('Agents panel parity', () => {
       { timeout: 5000, timeoutMsg: 'Expected runtime agent to appear in the project Agents widget' },
     );
 
-    const interruptBtn = await $(sel.agentCardInterrupt);
-    const terminateBtn = await $(sel.agentCardTerminate);
-    await interruptBtn.waitForDisplayed({ timeout: 5000 });
-    await terminateBtn.waitForDisplayed({ timeout: 5000 });
-    await interruptBtn.click();
+    await browser.waitUntil(
+      async () => browser.execute((intSel: string, termSel: string) => {
+        const visible = (s: string) => Array.from(document.querySelectorAll(s))
+          .find((el) => (el as HTMLElement).offsetParent !== null) as HTMLElement | undefined;
+        return !!(visible(intSel) && visible(termSel));
+      }, sel.agentCardInterrupt, sel.agentCardTerminate),
+      { timeout: 5000, timeoutMsg: 'Expected interrupt and terminate buttons to be visible on the runtime agent card' },
+    );
+    await browser.execute((intSel: string) => {
+      const btn = Array.from(document.querySelectorAll(intSel))
+        .find((el) => (el as HTMLElement).offsetParent !== null) as HTMLElement | undefined;
+      btn?.click();
+    }, sel.agentCardInterrupt);
 
     await browser.waitUntil(
       async () => (await (await $$(sel.agentCardRemove)).length) > 0,


### PR DESCRIPTION
The right sidebar now shows Agents before History (formerly Sessions) and defaults to the Agents tab when opening a workspace. The redundant "Agents" panel header has been replaced with a compact toolbar containing a search input and icon toggle buttons for hiding inactive agents and sub-agents, matching the existing diff panel icon button style. The home screen agents tab gets the same toolbar plus an additional toggle to hide root agents from other workspaces, so you can quickly narrow down to just bridge chats. E2e tests were updated to explicitly switch to the History tab where needed and to use visibility-aware selectors for agent card action buttons.