### PR TITLE
Add driver MCP workspace auto-open and query tool

### DIFF
--- a/src-tauri/src/agent_mcp_http.rs
+++ b/src-tauri/src/agent_mcp_http.rs
@@ -131,6 +131,7 @@ fn spawn_request_from(input: SpawnAgentToolInput) -> SpawnAgentRequest {
         parent_agent_id: input.parent_agent_id,
         name: input.name,
         ephemeral: input.ephemeral,
+        images: None,
     }
 }
 
@@ -187,6 +188,7 @@ impl TydeAgentMcpServer {
             parent_agent_id: explicit_parent,
             name: input.name,
             ephemeral: Some(false),
+            images: None,
         };
         if request.parent_agent_id.is_none() {
             request.parent_agent_id = caller_agent_id_from_parts(&parts);

--- a/src-tauri/src/debug_mcp_http.rs
+++ b/src-tauri/src/debug_mcp_http.rs
@@ -139,6 +139,15 @@ struct WaitForToolInput {
     timeout_ms: Option<u64>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+struct EvaluateToolInput {
+    /// JavaScript expression to evaluate in the webview. The body of an async
+    /// function — use `return` to produce a value. Has access to the full DOM
+    /// and any globals the app exposes.
+    expression: String,
+    timeout_ms: Option<u64>,
+}
+
 fn ok_json<T: Serialize>(value: T) -> Result<CallToolResult, McpError> {
     Ok(CallToolResult::success(vec![Content::json(value)?]))
 }
@@ -378,6 +387,22 @@ impl TydeDebugMcpServer {
             "timeout_ms": input.timeout_ms,
         });
         match call_ui_action(&self.app, "wait_for", params, input.timeout_ms).await {
+            Ok(value) => ok_json(value),
+            Err(err) => Ok(err_text(err)),
+        }
+    }
+
+    #[tool(
+        description = "Evaluate a JavaScript expression in the Tyde webview and return the result. The expression is the body of an async function — use `return` to produce a value. Has access to the full DOM and any globals the app exposes (e.g. window.__TYDE_BRIDGE__)."
+    )]
+    async fn tyde_debug_evaluate(
+        &self,
+        Parameters(input): Parameters<EvaluateToolInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let params = serde_json::json!({
+            "expression": input.expression,
+        });
+        match call_ui_action(&self.app, "evaluate", params, input.timeout_ms).await {
             Ok(value) => ok_json(value),
             Err(err) => Ok(err_text(err)),
         }

--- a/src-tauri/src/dev_instance.rs
+++ b/src-tauri/src/dev_instance.rs
@@ -15,7 +15,6 @@ pub(crate) struct DevInstance {
     /// Shared proxy state (cheap to clone for use across await points).
     proxy: Arc<McpProxy>,
     /// Project directory the dev instance was launched from.
-    #[allow(dead_code)]
     pub(crate) project_dir: String,
 }
 
@@ -190,6 +189,7 @@ impl McpProxy {
 pub(crate) async fn start_dev_instance(
     state: &AppState,
     project_dir: String,
+    workspace_path: Option<String>,
 ) -> Result<DevInstanceStartResult, String> {
     {
         let guard = state.dev_instance.lock();
@@ -249,7 +249,11 @@ pub(crate) async fn start_dev_instance(
         )
         .env("TYDE_DEBUG_MCP_HTTP_ENABLED", "true")
         .env("TYDE_MCP_HTTP_ENABLED", "false")
-        .env("TYDE_DRIVER_MCP_HTTP_ENABLED", "false")
+        .env("TYDE_DRIVER_MCP_HTTP_ENABLED", "false");
+    if let Some(ref ws) = workspace_path {
+        cmd.env("TYDE_OPEN_WORKSPACE", ws);
+    }
+    cmd
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
@@ -368,6 +372,12 @@ pub(crate) async fn stop_dev_instance(state: &AppState) -> Result<DevInstanceSto
     );
 
     Ok(DevInstanceStopResult { status: "stopped" })
+}
+
+/// Return the project directory of the running dev instance, if any.
+pub(crate) fn dev_instance_project_dir(state: &AppState) -> Option<String> {
+    let guard = state.dev_instance.lock();
+    guard.as_ref().map(|i| i.project_dir.clone())
 }
 
 /// Kill the child and its entire process tree.

--- a/src-tauri/src/driver_mcp_http.rs
+++ b/src-tauri/src/driver_mcp_http.rs
@@ -19,10 +19,7 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
 
-use crate::{
-    debug_mcp_http::extract_valid_png_data,
-    dev_instance, AppState,
-};
+use crate::{dev_instance, run_query_screenshot_agent, AppState};
 
 const DRIVER_MCP_HTTP_BIND_ENV: &str = "TYDE_DRIVER_MCP_HTTP_BIND_ADDR";
 const DEFAULT_BIND_ADDR: &str = "127.0.0.1:47773";
@@ -59,6 +56,10 @@ impl TydeDriverMcpServer {
 struct DevInstanceStartToolInput {
     /// Path to the Tyde project root directory to build and run.
     project_dir: String,
+    /// Optional workspace directory to open automatically on startup.
+    /// Bypasses the native file dialog so MCP clients can control the
+    /// full lifecycle without manual intervention.
+    workspace_path: Option<String>,
 }
 
 /// Empty input — no parameters needed.
@@ -103,14 +104,6 @@ struct ListTestIdsToolInput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-struct CaptureScreenshotToolInput {
-    selector: Option<String>,
-    index: Option<usize>,
-    max_dimension: Option<u32>,
-    timeout_ms: Option<u64>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 struct TypeToolInput {
     selector: String,
     text: String,
@@ -148,6 +141,15 @@ struct WaitForToolInput {
     timeout_ms: Option<u64>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+struct QueryScreenshotToolInput {
+    /// A visual question about the UI, e.g. "Is the sidebar collapsed or expanded?",
+    /// "What color is the error banner?", "Does the layout look correct?"
+    question: String,
+    /// Max wait time in milliseconds for the inspection agent (default 300000).
+    timeout_ms: Option<u64>,
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -178,7 +180,7 @@ async fn proxy_tool(
 }
 
 // ---------------------------------------------------------------------------
-// MCP Tools — 13 tools: 2 dev instance lifecycle + 11 proxied debug tools
+// MCP Tools — 13 tools: 2 dev instance lifecycle + 10 proxied debug tools + 1 query_screenshot
 // ---------------------------------------------------------------------------
 
 #[tool_router]
@@ -193,7 +195,7 @@ impl TydeDriverMcpServer {
         Parameters(input): Parameters<DevInstanceStartToolInput>,
     ) -> Result<CallToolResult, McpError> {
         let app_state = self.app.state::<AppState>();
-        match dev_instance::start_dev_instance(app_state.inner(), input.project_dir).await {
+        match dev_instance::start_dev_instance(app_state.inner(), input.project_dir, input.workspace_path).await {
             Ok(value) => ok_json(value),
             Err(err) => Ok(err_text(err)),
         }
@@ -277,58 +279,6 @@ impl TydeDriverMcpServer {
         proxy_tool(&self.app, "tyde_debug_list_testids", args).await
     }
 
-    #[tool(description = "Capture a PNG screenshot of the dev instance (optionally by selector).")]
-    async fn tyde_debug_capture_screenshot(
-        &self,
-        Parameters(input): Parameters<CaptureScreenshotToolInput>,
-    ) -> Result<CallToolResult, McpError> {
-        let args = serde_json::json!({
-            "selector": input.selector,
-            "index": input.index,
-            "max_dimension": input.max_dimension,
-            "timeout_ms": input.timeout_ms,
-        });
-
-        let app_state = self.app.state::<AppState>();
-        let value = match dev_instance::proxy_debug_tool_call(
-            app_state.inner(),
-            "tyde_debug_capture_screenshot",
-            args,
-        )
-        .await
-        {
-            Ok(value) => value,
-            Err(err) => return Ok(err_text(err)),
-        };
-
-        // The proxy returns the raw CallToolResult JSON. Extract the screenshot
-        // content so we can return a proper Content::image to the client.
-        // The dev instance's debug MCP returns content[1] as the JSON metadata.
-        let content_arr = value.get("content").and_then(|c| c.as_array());
-        if let Some(items) = content_arr {
-            // Look for the JSON metadata item that has `data` and `mime_type` fields.
-            for item in items {
-                if let Some(json_text) = item.get("text").and_then(|t| t.as_str()) {
-                    if let Ok(meta) = serde_json::from_str::<serde_json::Value>(json_text) {
-                        if let Ok(data) = extract_valid_png_data(&meta) {
-                            let out = vec![
-                                Content::image(data.to_string(), "image/png".to_string()),
-                                Content::json(meta)?,
-                            ];
-                            return Ok(CallToolResult::success(out));
-                        }
-                    }
-                }
-            }
-        }
-
-        // If we couldn't extract the image, return the raw proxy result.
-        match serde_json::from_value::<CallToolResult>(value.clone()) {
-            Ok(result) => Ok(result),
-            Err(_) => ok_json(value),
-        }
-    }
-
     #[tool(description = "Click a UI element in the dev instance by CSS selector.")]
     async fn tyde_debug_click(
         &self,
@@ -402,6 +352,29 @@ impl TydeDriverMcpServer {
             "timeout_ms": input.timeout_ms,
         });
         proxy_tool(&self.app, "tyde_debug_wait_for", args).await
+    }
+
+    // -- High-level screenshot query -------------------------------------------
+
+    #[tool(
+        description = "Ask a visual question about the dev instance UI by taking a screenshot and having an agent describe what it sees. Use this for visual/styling validation — layout, colors, spacing, visual state. For DOM-level questions (text content, element presence, test IDs, attributes), prefer the targeted debug tools instead: tyde_debug_get_text, tyde_debug_query_elements, tyde_debug_list_testids."
+    )]
+    async fn tyde_debug_query_screenshot(
+        &self,
+        Parameters(input): Parameters<QueryScreenshotToolInput>,
+    ) -> Result<CallToolResult, McpError> {
+        let app_state = self.app.state::<AppState>();
+        match run_query_screenshot_agent(
+            &self.app,
+            app_state.inner(),
+            input.question,
+            input.timeout_ms,
+        )
+        .await
+        {
+            Ok(answer) => Ok(CallToolResult::success(vec![Content::text(answer)])),
+            Err(err) => Ok(err_text(err)),
+        }
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -495,6 +495,9 @@ pub(crate) struct SpawnAgentRequest {
     pub(crate) parent_agent_id: Option<u64>,
     pub(crate) name: Option<String>,
     pub(crate) ephemeral: Option<bool>,
+    /// Images to attach to the initial message sent to the agent.
+    #[serde(skip)]
+    pub(crate) images: Option<Vec<ImageAttachment>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1008,18 +1011,14 @@ fn is_valid_session_id(session_id: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
-fn configured_backend_kind() -> Result<BackendKind, String> {
-    let backend_raw = std::env::var("TYDE_BACKEND_KIND").or_else(|_| std::env::var("TYDE_BACKEND"));
-    match backend_raw {
-        Ok(raw) => raw.parse::<BackendKind>(),
-        Err(_) => Ok(BackendKind::Tycode),
-    }
+fn configured_backend_kind() -> BackendKind {
+    BackendKind::Tycode
 }
 
 fn resolve_requested_backend_kind(backend_kind: Option<String>) -> Result<BackendKind, String> {
     match backend_kind {
         Some(raw) if !raw.trim().is_empty() => raw.parse::<BackendKind>(),
-        _ => configured_backend_kind(),
+        _ => Ok(configured_backend_kind()),
     }
 }
 
@@ -1081,6 +1080,11 @@ struct BackendDependencyStatus {
     codex: BackendDepResult,
     claude: BackendDepResult,
     kiro: BackendDepResult,
+}
+
+#[tauri::command]
+fn get_initial_workspace() -> Option<String> {
+    std::env::var("TYDE_OPEN_WORKSPACE").ok()
 }
 
 #[tauri::command]
@@ -1510,6 +1514,7 @@ pub(crate) async fn spawn_agent_internal(
         parent_agent_id,
         name,
         ephemeral,
+        images,
     } = request;
 
     if workspace_roots.iter().all(|root| root.trim().is_empty()) {
@@ -1619,7 +1624,7 @@ pub(crate) async fn spawn_agent_internal(
         conversation_id,
         SessionCommand::SendMessage {
             message: prompt,
-            images: None,
+            images,
         },
     )
     .await?;
@@ -1893,6 +1898,115 @@ pub(crate) async fn run_agent_internal(
     Ok(agent_result_from_info(&info))
 }
 
+const QUERY_SCREENSHOT_PREAMBLE: &str = "\
+You are a visual inspector for a Tyde dev instance. A screenshot of the current UI \
+is attached to this message.
+
+Your job is to answer a visual question about the UI based on the screenshot. \
+Provide a concise, factual answer.
+
+Guidelines:
+- Be concise — your entire response will be returned as a text summary to another agent
+- Focus on answering the specific question asked
+- Describe what you see: layout, colors, spacing, visual state of elements
+- Only answer based on what is visually apparent in the screenshot
+
+Question: ";
+
+/// Take a screenshot of the dev instance, then spawn an ephemeral agent with the
+/// image attached to answer a visual question about the UI.
+pub(crate) async fn run_query_screenshot_agent(
+    app: &tauri::AppHandle,
+    state: &AppState,
+    question: String,
+    timeout_ms: Option<u64>,
+) -> Result<String, String> {
+    // 1. Take a screenshot via the debug MCP proxy.
+    let screenshot_result = dev_instance::proxy_debug_tool_call(
+        state,
+        "tyde_debug_capture_screenshot",
+        serde_json::json!({}),
+    )
+    .await?;
+
+    // 2. Extract the base64 PNG data from the proxy response.
+    let content_arr = screenshot_result
+        .get("content")
+        .and_then(|c| c.as_array())
+        .ok_or("Screenshot response missing content array")?;
+
+    let mut png_base64: Option<String> = None;
+    for item in content_arr {
+        if let Some(json_text) = item.get("text").and_then(|t| t.as_str()) {
+            if let Ok(meta) = serde_json::from_str::<serde_json::Value>(json_text) {
+                if let Ok(data) = crate::debug_mcp_http::extract_valid_png_data(&meta) {
+                    png_base64 = Some(data.to_string());
+                    break;
+                }
+            }
+        }
+    }
+    let png_base64 =
+        png_base64.ok_or("Could not extract PNG data from screenshot response")?;
+
+    // 3. Build the image attachment.
+    let image_size = png_base64.len() as u64;
+    let image = ImageAttachment {
+        data: png_base64,
+        media_type: "image/png".to_string(),
+        name: "screenshot.png".to_string(),
+        size: image_size,
+    };
+
+    // 4. Spawn an ephemeral agent with the screenshot attached.
+    let prompt = format!("{QUERY_SCREENSHOT_PREAMBLE}{question}");
+    let project_dir = dev_instance::dev_instance_project_dir(state)
+        .ok_or("No dev instance running")?;
+
+    let request = SpawnAgentRequest {
+        workspace_roots: vec![project_dir],
+        prompt,
+        backend_kind: None,
+        parent_agent_id: None,
+        name: Some("__internal_query_screenshot__".to_string()),
+        ephemeral: Some(true),
+        images: Some(vec![image]),
+    };
+
+    let spawn_resp = spawn_agent_internal(app, state, request).await?;
+    let agent_id = spawn_resp.agent_id;
+
+    let wait_result = wait_for_agent_internal(
+        state,
+        WaitForAgentRequest {
+            agent_id,
+            timeout_ms: Some(timeout_ms.unwrap_or(300_000)),
+        },
+    )
+    .await;
+
+    // Collect result and terminate regardless of wait outcome.
+    let result = collect_agent_result_internal(
+        state,
+        AgentIdRequest { agent_id },
+    )
+    .await;
+
+    let _ = terminate_agent_internal(
+        state,
+        AgentIdRequest { agent_id },
+    )
+    .await;
+
+    // If the wait itself failed (timeout), return that error.
+    wait_result?;
+
+    let collected = result?;
+    collected
+        .final_message
+        .ok_or_else(|| "Query screenshot agent finished without producing a response".to_string())
+}
+
 /// epoll-style wait: block until any of the watched agents becomes idle.
 /// Returns the idle agents and the list of still-running ones.
 pub(crate) async fn await_agents_internal(
@@ -2051,6 +2165,7 @@ async fn spawn_agent(
             parent_agent_id,
             name,
             ephemeral,
+            images: None,
         },
     )
     .await
@@ -3067,6 +3182,7 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            get_initial_workspace,
             check_backend_dependencies,
             set_disabled_backends,
             install_backend_dependency,

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -382,6 +382,7 @@ fn build_local_command(workspace_path: &str) -> CommandBuilder {
     if !cfg!(target_os = "windows") {
         cmd.arg("-l");
     }
+    cmd.env("TERM", "xterm-256color");
     cmd.cwd(workspace_path);
     cmd
 }
@@ -395,5 +396,6 @@ fn build_remote_command(host: &str, path: &str) -> CommandBuilder {
         shell_quote_arg(path)
     );
     cmd.arg(remote_cmd);
+    cmd.env("TERM", "xterm-256color");
     cmd
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import {
   addRecentWorkspace,
   cancelConversation,
   closeConversation,
+  getInitialWorkspace,
   gitWorktreeAdd,
   gitWorktreeRemove,
   interruptAgent,
@@ -50,7 +51,7 @@ import { WorkspaceView } from "./workspace_view";
 
 const HOME_BRIDGE_VIEW_ID = "__home_bridge__";
 const HOME_BRIDGE_LABEL = "Bridge";
-const INTERNAL_TITLE_AGENT_PREFIX = "__internal_title__";
+const INTERNAL_AGENT_PREFIX = "__internal_";
 
 export class AppController {
   private notifications!: NotificationManager;
@@ -490,7 +491,7 @@ export class AppController {
     if (this.hiddenRuntimeAgentIds.has(agent.agent_id)) return false;
 
     const name = agent.name.trim();
-    if (name.startsWith(INTERNAL_TITLE_AGENT_PREFIX)) return false;
+    if (name.startsWith(INTERNAL_AGENT_PREFIX)) return false;
 
     // Backward compatibility for older title helpers created before the internal prefix.
     if (/^title\s+\d+$/i.test(name)) return false;
@@ -1301,6 +1302,12 @@ export class AppController {
   }
 
   private async bootstrapStartup(): Promise<void> {
+    const initialWorkspace = await getInitialWorkspace();
+    if (initialWorkspace) {
+      await this.openWorkspacePath(initialWorkspace);
+      return;
+    }
+
     const startupProject = this.projectState.getActiveProject();
 
     if (!startupProject) {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -540,3 +540,7 @@ export async function openWorkspaceDialog(): Promise<string | null> {
     throw new Error(friendlyError(String(err)));
   }
 }
+
+export async function getInitialWorkspace(): Promise<string | null> {
+  return invoke<string | null>("get_initial_workspace");
+}

--- a/src/debug_ui_bridge.ts
+++ b/src/debug_ui_bridge.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { domToCanvas } from "modern-screenshot";
 import { submitDebugUiResponse } from "./bridge";
@@ -532,6 +533,31 @@ async function handleWaitFor(
   );
 }
 
+async function handleEvaluate(
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  const expression = asString(params.expression);
+  if (!expression || expression.trim().length === 0) {
+    throw new Error("evaluate requires a non-empty expression");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const AsyncFunction = (async () => {}).constructor as new (
+    ...args: string[]
+  ) => (...args: unknown[]) => Promise<unknown>;
+  const fn = new AsyncFunction("invoke", expression);
+  const result = await fn(invoke);
+
+  // Clamp serialised output so we don't blow up the MCP response.
+  const json = JSON.stringify(result, null, 2) ?? "undefined";
+  const MAX_LEN = 100_000;
+  return {
+    value: json.length <= MAX_LEN ? result : undefined,
+    display:
+      json.length > MAX_LEN ? `${json.slice(0, MAX_LEN)}…(truncated)` : json,
+  };
+}
+
 async function handleCaptureScreenshot(
   params: Record<string, unknown>,
 ): Promise<unknown> {
@@ -647,6 +673,8 @@ async function executeAction(
       return handleWaitFor(params);
     case "capture_screenshot":
       return handleCaptureScreenshot(params);
+    case "evaluate":
+      return handleEvaluate(params);
     default:
       throw new Error(`Unsupported debug UI action '${action}'`);
   }


### PR DESCRIPTION
Dev instances spawned via the driver MCP can now auto-open a workspace through the new workspace_path parameter on tyde_dev_instance_start, which passes the path as TYDE_OPEN_WORKSPACE to the child process. The frontend reads this in bootstrapStartup and opens the workspace before falling through to normal restore logic, eliminating the need for manual file dialog interaction during automated testing.

The screenshot tool on the driver has been replaced with tyde_debug_query_screenshot, which takes a screenshot internally via the debug MCP proxy, attaches it as an image to an ephemeral agent, and returns the agent's text answer. This avoids sending raw PNG data back to the calling agent's context window. The ephemeral agent is hidden from the agents panel via the __internal_ name prefix and terminated after producing its response.

SpawnAgentRequest now supports an images field for attaching images to the initial message sent to an agent. The TYDE_BACKEND_KIND env var override has been removed in favor of always defaulting to Tycode when no explicit backend is requested.